### PR TITLE
Align C probabilities struct with rust struct

### DIFF
--- a/crates/wildbg-c/src/lib.rs
+++ b/crates/wildbg-c/src/lib.rs
@@ -74,14 +74,16 @@ pub unsafe extern "C" fn wildbg_free(ptr: *mut Wildbg) {
 #[repr(C)]
 #[derive(Default)]
 pub struct CProbabilities {
-    /// Cubeless probability to win the game. This includes gammons and backgammons.
-    win: c_float,
-    /// Probability to win gammon or backgammon.
-    win_g: c_float,
+    /// Cubeless probability to win the game without gammon or backgammon
+    win_normal: c_float,
+    /// Probability to win gammon.
+    win_gammon: c_float,
     /// Probability to win backgammon.
     win_bg: c_float,
-    /// Probability to lose gammon or backgammon.
-    lose_g: c_float,
+    /// Probability to lose the game without gammon or backgammon.
+    lose_normal: c_float,
+    /// Probability to lose gammon.
+    lose_gammon: c_float,
     /// Probability to lose backgammon.
     lose_bg: c_float,
 }
@@ -89,10 +91,11 @@ pub struct CProbabilities {
 impl From<&Probabilities> for CProbabilities {
     fn from(value: &Probabilities) -> Self {
         Self {
-            win: value.win_normal + value.win_gammon + value.win_bg,
-            win_g: value.win_gammon + value.win_bg,
+            win_normal: value.win_normal,
+            win_gammon: value.win_gammon,
             win_bg: value.win_bg,
-            lose_g: value.lose_gammon + value.lose_bg,
+            lose_normal: value.lose_normal,
+            lose_gammon: value.lose_gammon,
             lose_bg: value.lose_bg,
         }
     }
@@ -250,10 +253,11 @@ mod tests {
         };
 
         let c_probs: CProbabilities = (&model_probs).into();
-        assert_eq!(c_probs.win, 0.7);
-        assert_eq!(c_probs.win_g, 0.38);
+        assert_eq!(c_probs.win_normal, 0.32);
+        assert_eq!(c_probs.win_gammon, 0.26);
         assert_eq!(c_probs.win_bg, 0.12);
-        assert_eq!(c_probs.lose_g, 0.15);
+        assert_eq!(c_probs.lose_normal, 0.15);
+        assert_eq!(c_probs.lose_gammon, 0.1);
         assert_eq!(c_probs.lose_bg, 0.05);
     }
 

--- a/crates/wildbg-c/wildbg.h
+++ b/crates/wildbg-c/wildbg.h
@@ -49,21 +49,25 @@ typedef struct BgConfig {
 
 typedef struct CProbabilities {
   /**
-   * Cubeless probability to win the game. This includes gammons and backgammons.
+   * Cubeless probability to win the game without gammon or backgammon
    */
-  float win;
+  float win_normal;
   /**
-   * Probability to win gammon or backgammon.
+   * Probability to win gammon.
    */
-  float win_g;
+  float win_gammon;
   /**
    * Probability to win backgammon.
    */
   float win_bg;
   /**
-   * Probability to lose gammon or backgammon.
+   * Probability to lose the game without gammon or backgammon.
    */
-  float lose_g;
+  float lose_normal;
+  /**
+   * Probability to lose gammon.
+   */
+  float lose_gammon;
   /**
    * Probability to lose backgammon.
    */


### PR DESCRIPTION
Changes:
- Add the missing `lose_normal` probability to the c struct
- Align the C API to the probability struct in the rust lib. The C API now returns individual probabilities for win/lose for normal, gammon, and backgammon types